### PR TITLE
Service for parsing adress using Google Maps API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.ruby-version
 /Gemfile.lock
 /_yardoc/
 /coverage/

--- a/address_parser.gemspec
+++ b/address_parser.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "webmock"
 end

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "address_parser"
+require 'services/parse_with_google_maps_api_service'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/address_parser.rb
+++ b/lib/address_parser.rb
@@ -8,6 +8,29 @@ require 'json'
 
 module AddressParser
 
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  def self.new(address, use_google_maps=nil)
+    Base.new(address, use_google_maps)
+  end
+
+  class Configuration
+    attr_accessor :google_maps_api_key, :google_maps_client_id, :google_maps_cryptographic_key
+
+    def initialize
+      @google_maps_api_key = nil
+      @google_maps_client_id = nil
+      @google_maps_cryptographic_key = nil
+    end
+  end
+
   def self.new(address, g_maps_api_key=nil)
     Base.new(address, g_maps_api_key)
   end

--- a/lib/address_parser.rb
+++ b/lib/address_parser.rb
@@ -2,18 +2,21 @@ require 'address_parser/version'
 require 'address_parser/states'
 require 'address_parser/street_types'
 require 'address_parser/exceptions'
+require 'net/http'
+require 'uri'
+require 'json'
 
 module AddressParser
 
-  def self.new(address)
-    Base.new(address)
+  def self.new(address, g_maps_api_key=nil)
+    Base.new(address, g_maps_api_key)
   end
 
   class Base
     include States
     include StreetTypes
 
-    def initialize(address)
+    def initialize(address, g_maps_api_key=nil)
       @address             = address
 
       @unit_and_number     = nil
@@ -26,6 +29,7 @@ module AddressParser
       @postcode_pattern    = %r{\s?(?<postcode>(?:[2-7]\d{3}|08\d{2}))$}
       @unit_number_pattern = %r{((?<unit>.*)(?<=[\/|\s])+)?(?<number>[a-z\d-]*)$}i
 
+      @g_maps_api_key = g_maps_api_key
       @result = {}
     end
 
@@ -47,7 +51,57 @@ module AddressParser
 
       extract_suburb
 
+      # only use Google maps for adress parsing when api_key is present
+      make_g_maps_api_call if @g_maps_api_key
+
       @result
+    end
+
+    def make_g_maps_api_call
+      g_maps_results = {}
+      uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?address=#{URI.encode(@address)},
+        +Australia&
+        key=#{@g_maps_api_key}&
+        channel=address-parser"
+      )
+      http = Net::HTTP.new(uri.host)
+      response = http.request(Net::HTTP::Get.new(uri.request_uri))
+      response = JSON.parse(response.body)
+
+      if response["status"] == "OK"
+        response["results"][0]["address_components"].each do |component|
+          case component["types"][0]
+            when "subpremise"
+              g_maps_results[:unit] = component["long_name"]
+            when "street_number"
+              g_maps_results[:number] = component["long_name"]
+            when "route"
+              g_maps_results[:street] = component["long_name"]
+            when "locality"
+              g_maps_results[:suburb] = component["long_name"]
+            when "administrative_area_level_1"
+              g_maps_results[:state] = component["short_name"]
+            when "postal_code"
+              g_maps_results[:postcode] = component["long_name"]
+          end
+        end
+
+        if g_maps_results[:street]
+          g_maps_results[:street_type] = STREET_TYPES.flatten.detect do |s|
+            @street_type_pattern  = Regexp.new(
+              "(?<=[\\s|,])#{s}(?=(?:\\s\\d)|\\z)",
+              Regexp::IGNORECASE
+            )
+            g_maps_results[:street] =~ @street_type_pattern
+          end
+        end
+
+        if g_maps_results[:street_type]
+          g_maps_results[:street] = g_maps_results[:street].gsub(g_maps_results[:street_type], '').strip
+        end
+      end
+
+      @result[:g_maps_results] = g_maps_results
     end
 
     def extract_pobox

--- a/lib/services/parse_with_google_maps_api_service.rb
+++ b/lib/services/parse_with_google_maps_api_service.rb
@@ -17,9 +17,9 @@ module Services
       uri = URI.parse(prepare_google_maps_api_url)
       http = Net::HTTP.new(uri.host)
       response = http.request(Net::HTTP::Get.new(uri.request_uri))
-      response = JSON.parse(response.body)
+      response = JSON.parse(response.body) if response.code == "200"
 
-      if response["status"] == "OK"
+      if response && response["status"] == "OK"
         response["results"][0]["address_components"].each do |component|
           case component["types"][0]
             when "subpremise"

--- a/lib/services/parse_with_google_maps_api_service.rb
+++ b/lib/services/parse_with_google_maps_api_service.rb
@@ -1,0 +1,95 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+module Services
+
+  class ParseWithGoogleMapsApiService
+
+    def initialize(address)
+      @address = address
+    end
+
+    def parse
+      google_maps_results = {}
+
+      uri = URI.parse(prepare_google_maps_api_url)
+      http = Net::HTTP.new(uri.host)
+      response = http.request(Net::HTTP::Get.new(uri.request_uri))
+      response = JSON.parse(response.body)
+
+      if response["status"] == "OK"
+        response["results"][0]["address_components"].each do |component|
+          case component["types"][0]
+            when "subpremise"
+              google_maps_results[:unit] = component["long_name"]
+            when "street_number"
+              google_maps_results[:number] = component["long_name"]
+            when "route"
+              google_maps_results[:street] = component["long_name"]
+            when "locality"
+              google_maps_results[:suburb] = component["long_name"]
+            when "administrative_area_level_1"
+              google_maps_results[:state] = component["short_name"]
+            when "postal_code"
+              google_maps_results[:postcode] = component["long_name"]
+          end
+        end
+
+        if google_maps_results[:street]
+          google_maps_results[:street_type] = AddressParser::StreetTypes::STREET_TYPES.flatten.detect do |s|
+            @street_type_pattern  = Regexp.new(
+              "(?<=[\\s|,])#{s}(?=(?:\\s\\d)|\\z)",
+              Regexp::IGNORECASE
+            )
+            google_maps_results[:street] =~ @street_type_pattern
+          end
+        end
+
+        if google_maps_results[:street_type]
+          google_maps_results[:street] = google_maps_results[:street].gsub(google_maps_results[:street_type], '').strip
+        end
+      end
+
+      google_maps_results
+    end
+
+    def prepare_google_maps_api_url
+      url = "https://maps.googleapis.com/maps/api/geocode/json?address=#{URI.encode(@address)},+Australia"
+
+      unless AddressParser.configuration.nil?
+        if AddressParser.configuration.google_maps_client_id && AddressParser.configuration.google_maps_cryptographic_key
+          url += "&client=#{AddressParser.configuration.google_maps_client_id}"
+          url += "&channel=address-parser"
+          signature = generate_signature(url)
+          url += "&signature=#{signature}"
+        elsif AddressParser.configuration.google_maps_api_key
+          url += "&key=#{AddressParser.configuration.google_maps_api_key}"
+        end
+      end
+
+      url
+    end
+
+    private
+
+     # stolen from https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/lookups/google_premier.rb
+    def generate_signature(url)
+      raw_private_key = url_safe_base64_decode(AddressParser.configuration.google_maps_cryptographic_key)
+      digest = OpenSSL::Digest.new('sha1')
+      raw_signature = OpenSSL::HMAC.digest(digest, raw_private_key, url)
+      url_safe_base64_encode(raw_signature)
+    end
+
+    def url_safe_base64_decode(base64_string)
+      Base64.decode64(base64_string.tr('-_', '+/'))
+    end
+
+    def url_safe_base64_encode(raw)
+      Base64.encode64(raw).tr('+/', '-_').strip
+    end
+
+  end
+
+end

--- a/test/address_parser_test.rb
+++ b/test/address_parser_test.rb
@@ -161,4 +161,110 @@ class TestAddressParser < Minitest::Test
     assert_equal 'NSW',    address[:state]
     assert_equal '2066',   address[:postcode]
   end
+
+  def test_calling_g_maps_api_for_address_without_commas
+    response_hash =
+    {
+      "results": [
+        {
+          "address_components": [
+            {
+              "long_name": "118",
+              "short_name": "118",
+              "types": [
+                "street_number"
+              ]
+            },
+            {
+              "long_name": "Walker Street",
+              "short_name": "Walker St",
+              "types": [
+                "route"
+              ]
+            },
+            {
+              "long_name": "Dandenong",
+              "short_name": "Dandenong",
+              "types": [
+                "locality",
+                "political"
+              ]
+            },
+            {
+              "long_name": "Victoria",
+              "short_name": "VIC",
+              "types": [
+                "administrative_area_level_1",
+                "political"
+              ]
+            },
+            {
+              "long_name": "Australia",
+              "short_name": "AU",
+              "types": [
+                "country",
+                "political"
+              ]
+            },
+            {
+              "long_name": "3175",
+              "short_name": "3175",
+              "types": [
+                "postal_code"
+              ]
+            }
+          ],
+          "formatted_address": "118 Walker St, Dandenong VIC 3175, Australia",
+          "geometry": {
+            "bounds": {
+              "northeast": {
+                "lat": -37.9877233,
+                "lng": 145.2153979
+              },
+              "southwest": {
+                "lat": -37.9877349,
+                "lng": 145.2153864
+              }
+            },
+            "location": {
+              "lat": -37.9877349,
+              "lng": 145.2153979
+            },
+            "location_type": "RANGE_INTERPOLATED",
+            "viewport": {
+              "northeast": {
+                "lat": -37.98638011970851,
+                "lng": 145.2167411302915
+              },
+              "southwest": {
+                "lat": -37.98907808029151,
+                "lng": 145.2140431697085
+              }
+            }
+          },
+          "place_id": "EiwxMTggV2Fsa2VyIFN0LCBEYW5kZW5vbmcgVklDIDMxNzUsIEF1c3RyYWxpYQ",
+          "types": [
+            "street_address"
+          ]
+        }
+      ],
+      "status": "OK"
+    }
+
+  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?%20%20%20%20%20%20%20%20channel="\
+    "address-parser&%20%20%20%20%20%20%20%20key=123456&address=118%20Walker%20Street%20DANDENONG,"\
+    "%20%20%20%20%20%20%20%20%20Australia").
+    with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
+    to_return(:status => 200, :body => response_hash.to_json, :headers => {})
+
+    address = AddressParser::Base.new("118 Walker Street DANDENONG VIC 3175",
+      "123456").process_address[:g_maps_results]
+
+    assert_equal '118',       address[:number]
+    assert_equal 'Walker',    address[:street]
+    assert_equal 'Street',    address[:street_type]
+    assert_equal 'Dandenong', address[:suburb]
+    assert_equal 'VIC',       address[:state]
+    assert_equal '3175',      address[:postcode]
+  end
 end

--- a/test/address_parser_test.rb
+++ b/test/address_parser_test.rb
@@ -163,99 +163,11 @@ class TestAddressParser < Minitest::Test
   end
 
   def test_calling_g_maps_api_for_address_without_commas
-    response_hash =
-    {
-      "results": [
-        {
-          "address_components": [
-            {
-              "long_name": "118",
-              "short_name": "118",
-              "types": [
-                "street_number"
-              ]
-            },
-            {
-              "long_name": "Walker Street",
-              "short_name": "Walker St",
-              "types": [
-                "route"
-              ]
-            },
-            {
-              "long_name": "Dandenong",
-              "short_name": "Dandenong",
-              "types": [
-                "locality",
-                "political"
-              ]
-            },
-            {
-              "long_name": "Victoria",
-              "short_name": "VIC",
-              "types": [
-                "administrative_area_level_1",
-                "political"
-              ]
-            },
-            {
-              "long_name": "Australia",
-              "short_name": "AU",
-              "types": [
-                "country",
-                "political"
-              ]
-            },
-            {
-              "long_name": "3175",
-              "short_name": "3175",
-              "types": [
-                "postal_code"
-              ]
-            }
-          ],
-          "formatted_address": "118 Walker St, Dandenong VIC 3175, Australia",
-          "geometry": {
-            "bounds": {
-              "northeast": {
-                "lat": -37.9877233,
-                "lng": 145.2153979
-              },
-              "southwest": {
-                "lat": -37.9877349,
-                "lng": 145.2153864
-              }
-            },
-            "location": {
-              "lat": -37.9877349,
-              "lng": 145.2153979
-            },
-            "location_type": "RANGE_INTERPOLATED",
-            "viewport": {
-              "northeast": {
-                "lat": -37.98638011970851,
-                "lng": 145.2167411302915
-              },
-              "southwest": {
-                "lat": -37.98907808029151,
-                "lng": 145.2140431697085
-              }
-            }
-          },
-          "place_id": "EiwxMTggV2Fsa2VyIFN0LCBEYW5kZW5vbmcgVklDIDMxNzUsIEF1c3RyYWxpYQ",
-          "types": [
-            "street_address"
-          ]
-        }
-      ],
-      "status": "OK"
-    }
-
-  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?%20%20%20%20%20%20%20%20channel="\
-    "address-parser&%20%20%20%20%20%20%20%20key=123456&address=118%20Walker%20Street%20DANDENONG,"\
-    "%20%20%20%20%20%20%20%20%20Australia").
-    with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-    to_return(:status => 200, :body => response_hash.to_json, :headers => {})
+    stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?%20%20%20%20%20%20%20%20channel="\
+      "address-parser&%20%20%20%20%20%20%20%20key=123456&address=118%20Walker%20Street%20DANDENONG,"\
+      "%20%20%20%20%20%20%20%20%20Australia").
+      with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => GoogleFixtures.walker_street_response_hash.to_json)
 
     address = AddressParser::Base.new("118 Walker Street DANDENONG VIC 3175",
       "123456").process_address[:g_maps_results]

--- a/test/address_parser_test.rb
+++ b/test/address_parser_test.rb
@@ -161,22 +161,4 @@ class TestAddressParser < Minitest::Test
     assert_equal 'NSW',    address[:state]
     assert_equal '2066',   address[:postcode]
   end
-
-  def test_calling_g_maps_api_for_address_without_commas
-    stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?%20%20%20%20%20%20%20%20channel="\
-      "address-parser&%20%20%20%20%20%20%20%20key=123456&address=118%20Walker%20Street%20DANDENONG,"\
-      "%20%20%20%20%20%20%20%20%20Australia").
-      with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-      to_return(:status => 200, :body => GoogleFixtures.walker_street_response_hash.to_json)
-
-    address = AddressParser::Base.new("118 Walker Street DANDENONG VIC 3175",
-      "123456").process_address[:g_maps_results]
-
-    assert_equal '118',       address[:number]
-    assert_equal 'Walker',    address[:street]
-    assert_equal 'Street',    address[:street_type]
-    assert_equal 'Dandenong', address[:suburb]
-    assert_equal 'VIC',       address[:state]
-    assert_equal '3175',      address[:postcode]
-  end
 end

--- a/test/fixtures/google_fixtures.rb
+++ b/test/fixtures/google_fixtures.rb
@@ -1,0 +1,91 @@
+class GoogleFixtures
+  def self.walker_street_response_hash
+    {
+      "results": [
+        {
+          "address_components": [
+            {
+              "long_name": "118",
+              "short_name": "118",
+              "types": [
+                "street_number"
+              ]
+            },
+            {
+              "long_name": "Walker Street",
+              "short_name": "Walker St",
+              "types": [
+                "route"
+              ]
+            },
+            {
+              "long_name": "Dandenong",
+              "short_name": "Dandenong",
+              "types": [
+                "locality",
+                "political"
+              ]
+            },
+            {
+              "long_name": "Victoria",
+              "short_name": "VIC",
+              "types": [
+                "administrative_area_level_1",
+                "political"
+              ]
+            },
+            {
+              "long_name": "Australia",
+              "short_name": "AU",
+              "types": [
+                "country",
+                "political"
+              ]
+            },
+            {
+              "long_name": "3175",
+              "short_name": "3175",
+              "types": [
+                "postal_code"
+              ]
+            }
+          ],
+          "formatted_address": "118 Walker St, Dandenong VIC 3175, Australia",
+          "geometry": {
+            "bounds": {
+              "northeast": {
+                "lat": -37.9877233,
+                "lng": 145.2153979
+              },
+              "southwest": {
+                "lat": -37.9877349,
+                "lng": 145.2153864
+              }
+            },
+            "location": {
+              "lat": -37.9877349,
+              "lng": 145.2153979
+            },
+            "location_type": "RANGE_INTERPOLATED",
+            "viewport": {
+              "northeast": {
+                "lat": -37.98638011970851,
+                "lng": 145.2167411302915
+              },
+              "southwest": {
+                "lat": -37.98907808029151,
+                "lng": 145.2140431697085
+              }
+            }
+          },
+          "place_id": "EiwxMTggV2Fsa2VyIFN0LCBEYW5kZW5vbmcgVklDIDMxNzUsIEF1c3RyYWxpYQ",
+          "types": [
+            "street_address"
+          ]
+        }
+      ],
+      "status": "OK"
+    }
+
+  end
+end

--- a/test/google_maps_parser_test.rb
+++ b/test/google_maps_parser_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class TestGoogleMapsParser < Minitest::Test
+  def setup
+    AddressParser.configure do |config|
+      config.google_maps_api_key = nil
+      config.google_maps_client_id = nil
+      config.google_maps_cryptographic_key = nil
+    end
+  end
+
+  def test_calling_google_maps_api_for_address_without_commas
+    stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?"\
+      "address=118%20Walker%20Street%20DANDENONG,%20Australia").
+      with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => GoogleFixtures.walker_street_response_hash.to_json)
+
+    address = AddressParser::Base.new("118 Walker Street DANDENONG VIC 3175", true)
+      .process_address[:google_maps_results]
+
+    assert_equal '118',       address[:number]
+    assert_equal 'Walker',    address[:street]
+    assert_equal 'Street',    address[:street_type]
+    assert_equal 'Dandenong', address[:suburb]
+    assert_equal 'VIC',       address[:state]
+    assert_equal '3175',      address[:postcode]
+  end
+
+  def test_calling_google_maps_api_using_api_key
+    AddressParser.configure do |config|
+      config.google_maps_api_key = '123456'
+    end
+
+    google_maps_api_service = Services::ParseWithGoogleMapsApiService.new("118 Walker Street DANDENONG VIC 3175")
+    google_maps_api_url = google_maps_api_service.prepare_google_maps_api_url
+
+    assert_match /key=123456/, google_maps_api_url
+    refute_match /client=/, google_maps_api_url
+    refute_match /signature=/, google_maps_api_url
+  end
+
+  def test_calling_google_maps_api_using_client_id_and_signature
+    AddressParser.configure do |config|
+      config.google_maps_client_id = '654321'
+      config.google_maps_cryptographic_key = 'supersecretkey'
+    end
+
+    google_maps_api_service = Services::ParseWithGoogleMapsApiService.new("118 Walker Street DANDENONG VIC 3175")
+    google_maps_api_url = google_maps_api_service.prepare_google_maps_api_url
+
+    assert_match /client=654321/, google_maps_api_url
+    assert_match /signature=FJuT8i_VFo2bd3q3JoMep103DuY=/, google_maps_api_url
+    refute_match /key=/, google_maps_api_url
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'address_parser'
 
 require 'minitest/autorun'
+
+require 'webmock/minitest'
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,4 +5,8 @@ require 'minitest/autorun'
 
 require 'webmock/minitest'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!
+
+Dir[Dir.pwd + "/test/fixtures/google_fixtures.rb"].each do |file|
+  require file
+end


### PR DESCRIPTION
Added global configuration for setting google api key / client_id. Apps using this gem can set the values through initializer. If no config values are provided, service makes API calls without any user identification (low quota limits).